### PR TITLE
UP-7: Updating module to depend on addresshierarchy instead of addresshierarchyrwanda

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -34,10 +34,10 @@
 		</dependency>
 		<dependency>
 			<groupId>org.openmrs.module</groupId>
-			<artifactId>addresshierarchyrwanda-api</artifactId>
+			<artifactId>addresshierarchy-api</artifactId>
 			<type>jar</type>
 			<scope>provided</scope>
-			<version>${addresshierarchyrwandaVersion}</version>
+			<version>${addresshierarchyVersion}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.openmrs.module</groupId>

--- a/api/src/main/java/org/openmrs/module/rwandaprimarycare/impl/PrimaryCareServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/rwandaprimarycare/impl/PrimaryCareServiceImpl.java
@@ -8,8 +8,8 @@ import org.openmrs.Patient;
 import org.openmrs.PersonAttributeType;
 import org.openmrs.api.context.Context;
 import org.openmrs.api.impl.BaseOpenmrsService;
-import org.openmrs.module.addresshierarchyrwanda.AddressHierarchy;
-import org.openmrs.module.addresshierarchyrwanda.AddressHierarchyService;
+import org.openmrs.module.addresshierarchy.AddressHierarchyEntry;
+import org.openmrs.module.addresshierarchy.service.AddressHierarchyService;
 import org.openmrs.module.rwandaprimarycare.PrimaryCareBusinessLogic;
 import org.openmrs.module.rwandaprimarycare.PrimaryCareConstants;
 import org.openmrs.module.rwandaprimarycare.PrimaryCareService;
@@ -50,12 +50,12 @@ public class PrimaryCareServiceImpl extends BaseOpenmrsService implements Primar
 
 
 		} else if (searchType == PatientSearchType.COUNTRY){
-    	    List<AddressHierarchy> aList = ahs.getTopOfHierarchyList();
+    	    List<AddressHierarchyEntry> aList = ahs.getTopOfHierarchyList();
     	    if (aList != null && aList.size() > 0)
     	        results = new ArrayList<String>();
-    	    for (AddressHierarchy a : aList){
+    	    for (AddressHierarchyEntry a : aList){
     	        if (a != null && (a.getLocationName().toLowerCase().contains(search.toLowerCase()) || search.equals("")))
-    	            results.add(a.getAddressHierarchyId() + "|" + a.getLocationName());   
+    	            results.add(a.getAddressHierarchyEntryId() + "|" + a.getLocationName());   
     	    }
     	} else if (searchType == PatientSearchType.PROVINCE){
     	    results = addressHierarchyListtoStringList(ahs.getNextComponent(previousId), search);
@@ -140,12 +140,12 @@ public class PrimaryCareServiceImpl extends BaseOpenmrsService implements Primar
     }
     
     //TODO:   fill in cells of the hierarchy based on umudugudu??
-    private List<String> addressHierarchyListtoStringList(List<AddressHierarchy> ahList, String search){
+    private List<String> addressHierarchyListtoStringList(List<AddressHierarchyEntry> ahList, String search){
             List<String> stList = new ArrayList<String>();
-            for (AddressHierarchy ah : ahList){
+            for (AddressHierarchyEntry ah : ahList){
                 if (ah != null && ah.getLocationName() != null && (search.equals("") || ah.getLocationName().toLowerCase().contains(search.toLowerCase()))){
                     //we need to parse out address hierarchy ID before display, and set as javascript var on page.
-                    stList.add(ah.getAddressHierarchyId()+ "|" + ah.getLocationName());
+                    stList.add(ah.getAddressHierarchyEntryId()+ "|" + ah.getLocationName());
                 }    
             }
             if (stList.size() == 0)

--- a/omod/src/main/java/org/openmrs/module/rwandaprimarycare/dwr/PrimaryCareDWRService.java
+++ b/omod/src/main/java/org/openmrs/module/rwandaprimarycare/dwr/PrimaryCareDWRService.java
@@ -7,8 +7,8 @@ import java.util.Map;
 import org.apache.commons.lang.StringUtils;
 import org.openmrs.api.context.Context;
 import org.openmrs.messagesource.MessageSourceService;
-import org.openmrs.module.addresshierarchyrwanda.AddressHierarchy;
-import org.openmrs.module.addresshierarchyrwanda.AddressHierarchyService;
+import org.openmrs.module.addresshierarchy.AddressHierarchyEntry;
+import org.openmrs.module.addresshierarchy.service.AddressHierarchyService;
 
 public class PrimaryCareDWRService {
 
@@ -18,17 +18,17 @@ public class PrimaryCareDWRService {
         if (Context.getAuthenticatedUser() != null && parentId != null && searchString != null && !searchString.equals("")){
             AddressHierarchyService ahs = Context.getService(AddressHierarchyService.class);
             if (parentId.intValue() == 0){
-                List<AddressHierarchy> topList = ahs.getTopOfHierarchyList();
-                for (AddressHierarchy ah : topList){
+                List<AddressHierarchyEntry> topList = ahs.getTopOfHierarchyList();
+                for (AddressHierarchyEntry ah : topList){
                     if (ah != null && ah.getLocationName().equals(searchString))
-                        return ah.getAddressHierarchyId();
+                        return ah.getAddressHierarchyEntryId();
                 }
             } else {
                 
-                    List<AddressHierarchy> childList = ahs.getNextComponent(parentId);
-                    for (AddressHierarchy ahTmp : childList){
+                    List<AddressHierarchyEntry> childList = ahs.getNextComponent(parentId);
+                    for (AddressHierarchyEntry ahTmp : childList){
                         if (ahTmp != null && ahTmp.getLocationName().equals(searchString))
-                            return ahTmp.getAddressHierarchyId();
+                            return ahTmp.getAddressHierarchyEntryId();
                     }
                     
                 

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -14,7 +14,7 @@
 	<require_version>1.9.11</require_version>
 	
 	<require_modules>
-		<require_module>org.openmrs.module.addresshierarchyrwanda</require_module>
+		<require_module>org.openmrs.module.addresshierarchy</require_module>
 		<require_module>org.openmrs.module.idgen</require_module>
 		<require_module>org.openmrs.module.namephonetics</require_module>
 		<require_module>org.openmrs.module.mohappointment</require_module>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 	<properties>
 		<openMRSVersion>2.3.1</openMRSVersion>
 		<htmlformentryVersion>3.11.0</htmlformentryVersion>
-		<addresshierarchyrwandaVersion>1.2.9-SNAPSHOT</addresshierarchyrwandaVersion>
+		<addresshierarchyVersion>2.12.0</addresshierarchyVersion>
 		<idgenVersion>4.0</idgenVersion>
 		<namephoneticsVersion>1.5</namephoneticsVersion>
 		<mohappointmentVersion>0.3-SNAPSHOT</mohappointmentVersion>
@@ -77,8 +77,8 @@
 		</dependency>
 		<dependency>
 			<groupId>org.openmrs.module</groupId>
-			<artifactId>addresshierarchyrwanda-api</artifactId>
-			<version>${addresshierarchyrwandaVersion}</version>
+			<artifactId>addresshierarchy-api</artifactId>
+			<version>${addresshierarchyVersion}</version>
 			<type>jar</type>
 			<scope>provided</scope>
 		</dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 	<properties>
 		<openMRSVersion>2.3.1</openMRSVersion>
 		<htmlformentryVersion>3.11.0</htmlformentryVersion>
-		<addresshierarchyVersion>2.12.0</addresshierarchyVersion>
+		<addresshierarchyVersion>2.13.0</addresshierarchyVersion>
 		<idgenVersion>4.0</idgenVersion>
 		<namephoneticsVersion>1.5</namephoneticsVersion>
 		<mohappointmentVersion>0.3-SNAPSHOT</mohappointmentVersion>


### PR DESCRIPTION
- Updated `rwandaprimarycare pom` and `rwandaprimarycare-api` pom to depend on `addresshierarchy`

- Replaced `org.openmrs.module.addresshierarchyrwanda.AddressHierarchy` by `org.openmrs.module.addresshierarchy.AddressHierarchyEntry`

- Replaced `org.openmrs.module.addresshierarchyrwanda.AddressHierarchyService` by `org.openmrs.module.addresshierarchy.service.AddressHierarchyService`