### PR TITLE
UP-156: Add CI configuration for building and deploying snapshots upon each commit

### DIFF
--- a/.github/workflows/deploy-snapshots.yml
+++ b/.github/workflows/deploy-snapshots.yml
@@ -1,0 +1,40 @@
+# For every commit pushed to the master branch, this will compile, package, test, verify, and deploy
+# This is only configured to deploy to the SNAPSHOTS repository, so is not intended to be used for releases
+
+name: Deploy Snapshots
+
+on:
+  push:
+    branches: ['master']
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+
+      # Check out the code
+    - uses: actions/checkout@v2
+
+      # Enable caching of Maven dependencies to speed up job execution.  See https://github.com/actions/cache
+    - uses: actions/cache@v1
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-maven-
+
+      # Set up Java 1.8 with Maven including a .m2/settings.xml file.  See https://github.com/actions/setup-java
+    - name: Set up JDK 1.8 and Maven settings file
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+        server-id: openmrs-repo-modules-rwandaemr-snapshots
+        server-username: BINTRAY_USERNAME
+        server-password: BINTRAY_PASSWORD
+
+      # Execute the Maven deploy command to compile, package, test, verify, and publish to SNAPSHOT repository
+    - name: Maven Deploy
+      run: mvn -B deploy --file pom.xml
+      env:
+        BINTRAY_USERNAME: rwandaemr@gmail.com
+        BINTRAY_PASSWORD: ${{ secrets.RWANDA_EMR_BINTRAY_PASSWORD }}

--- a/.github/workflows/perform-release.yml
+++ b/.github/workflows/perform-release.yml
@@ -1,0 +1,83 @@
+# Performing a release is done by executing a perform-release event through a repository webhook.
+# This needs to be executed by issuing an authenticated REST Post operation, to prevent accidental or unauthorized releases.
+# This should involve a command such as the following:
+#
+#    export GITHUB_TOKEN=your-personal-access-token
+#    curl  -H "Authorization: token $GITHUB_TOKEN" \
+#      -H "Accept: application/vnd.github.everest-preview+json"  \
+#      -H "Content-Type: application/json" \
+#      --request POST \
+#      --data '{ "event_type": "perform-release", "client_payload": { "ref": "master" } }' \
+#      https://api.github.com/repos/Rwanda-EMR/openmrs-distro-rwandaemr/dispatches
+#
+# This will kick off this workflow, which will attempt to update the pom by removing SNAPSHOT, commit these changes,
+# build, test, and deploy this to the non-SNAPSHOT Maven repository, update the pom to next SNAPSHOT and commit.
+#
+# If you wish to release a new version off of a maintenance branch, you can change the ref to reflect the branch to use
+
+name: Perform Release
+
+on:
+  repository_dispatch:
+      types: ['perform-release']
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+
+      # Check out the code
+    - uses: actions/checkout@v2
+      with:
+        ref: '${{ github.event.client_payload.ref }}'
+
+      # Set up git config
+    - name: Setup Git Config
+      run: |
+        git config user.email "github-action@users.noreply.github.com"
+        git config user.name "Github Action"
+        git config user.password "$GITHUB_TOKEN"
+
+      # Enable caching of Maven dependencies to speed up job execution.  See https://github.com/actions/cache
+    - uses: actions/cache@v1
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-maven-
+
+      # Set up Java 1.8 with Maven including a server.xml file for authenticating to the non-SNAPSHOT repository
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+        server-id: openmrs-repo-modules-rwandaemr
+        server-username: BINTRAY_USERNAME
+        server-password: BINTRAY_PASSWORD
+
+      # Prepare the release.  This updates and commits pom to release version, tags, updates to next development version
+    - name: Prepare Release
+      run: mvn -B release:prepare
+
+      # Perform the release.  This checks out the tag from the previous step, builds, and deploys to Maven repository
+    - name: Perform Release
+      run: mvn -B release:perform
+      env:
+        BINTRAY_USERNAME: rwandaemr@gmail.comm
+        BINTRAY_PASSWORD: ${{ secrets.RWANDA_EMR_BINTRAY_PASSWORD }}
+
+      # Run setup-java again to replace the settings.xml with with the SNAPSHOT repository
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+        server-id: openmrs-repo-modules-rwandaemr-snapshots
+        server-username: BINTRAY_USERNAME
+        server-password: BINTRAY_PASSWORD
+
+      # Now run a final deploy to ensure the next SNAPSHOT is also built and deployed to Maven
+    - name: Maven Deploy
+      run: mvn -B -e clean deploy --file pom.xml
+      env:
+        BINTRAY_USERNAME: rwandaemr@gmail.com
+        BINTRAY_PASSWORD: ${{ secrets.RWANDA_EMR_BINTRAY_PASSWORD }}

--- a/.github/workflows/perform-release.yml
+++ b/.github/workflows/perform-release.yml
@@ -8,7 +8,7 @@
 #      -H "Content-Type: application/json" \
 #      --request POST \
 #      --data '{ "event_type": "perform-release", "client_payload": { "ref": "master" } }' \
-#      https://api.github.com/repos/Rwanda-EMR/openmrs-distro-rwandaemr/dispatches
+#      https://api.github.com/repos/Rwanda-EMR/openmrs-module-rwandaprimarycare/dispatches
 #
 # This will kick off this workflow, which will attempt to update the pom by removing SNAPSHOT, commit these changes,
 # build, test, and deploy this to the non-SNAPSHOT Maven repository, update the pom to next SNAPSHOT and commit.

--- a/.github/workflows/verify-prs.yml
+++ b/.github/workflows/verify-prs.yml
@@ -1,0 +1,34 @@
+# For every pull request, this will run mvn verify on the PR using Java 8
+
+name: Verify PRs
+
+on:
+  pull_request:
+    branches: ['master']
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+
+    steps:
+
+      # Check out the code
+    - uses: actions/checkout@v2
+
+      # Enable caching of Maven dependencies to speed up job execution.  See https://github.com/actions/cache
+    - uses: actions/cache@v1
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-maven-
+
+      # Set up Java 1.8 with Maven
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+
+      # Execute the Maven verify command to compile, package, test, verify
+    - name: Build with Maven
+      run: mvn -B verify --file pom.xml

--- a/README.md
+++ b/README.md
@@ -1,2 +1,60 @@
-openmrs-module-rwandaprimarycare
-================================
+# Rwanda Primary Care
+
+### [Github Actions](https://github.com/features/actions)
+
+For the RwandaEMR project, we have begun to establish the use of Github Actions for CI automation.  
+Github Actions are configured on a per-repository basis, and contain those workflows that you wish to configure for 
+that repository.  The advantage of this platform for the RwandaEMR project is that anyone who has write-access to the 
+repository can create or edit a CI workflow.
+
+Anyone can also easily view all of the details of each workflow within the code project itself.  
+See the [workflows defined here](https://github.com/Rwanda-EMR/openmrs-module-rwandaprimarycare/tree/master/.github/workflows) 
+for how this is configured for this project.
+
+## Standard Workflows
+
+### verify-prs:
+
+For every pull request that is issued against the configured branches (currently just master), 
+this job runs a “mvn verify”, which compiles, tests, and verifies that the there are no errors.
+
+### deploy-snapshots:
+
+For every commit pushed to the configured branches (currently master), this job runs a “mvn deploy”, which compiles, 
+executes tests, and verifies that this builds without errors, and if so, deploys to the OpenMRS Maven Snapshots repository 
+that is configured in the distributionManagement section of 
+the [pom.xml](https://github.com/Rwanda-EMR/openmrs-module-rwandaprimarycare/blob/master/pom.xml)
+
+### perform-release:
+
+This job exists to perform a versioned, non-SNAPSHOT release.  
+This is not automatically executed,  but rather is initiated by an explicit, authenticated REST request.  
+This job runs the following maven goals:
+
+```mvn release:prepare```
+- Removes “-SNAPSHOT” from pom.xml files and commits
+- Tags this commit with the version number
+- Increments the version in the pom.xml to the next snapshot version, and commits this
+
+```mvn release:perform```
+- Checks out the tag with the version created in the release:prepare step
+- Builds the code artifacts
+- Deploys these to the OpenMRS Maven repository as configured in pom distributionManagement section
+
+```mvn deploy```
+- Builds the next snapshot version created at the end of release:prepare
+- Deploys this to the OpenMRS Maven snapshots repository that is configured in the pom
+
+To initiate the release workflow one would take the following steps:
+* [Create a personal access token](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line) to authenticate into Github with minimal permissions (public_repo and write:repo_hook)
+* In a terminal, set the GITHUB_TOKEN environment variable to this token value:
+```export GITHUB_TOKEN=areallylongtokenthatisgeneratedingithub```
+* Issue a request to hit the deployment endpoint:
+```
+curl  -H "Authorization: token $GITHUB_TOKEN" \
+      -H "Accept: application/vnd.github.everest-preview+json"  \
+      -H "Content-Type: application/json" \
+      --request POST \
+      --data '{"event_type": "perform-release"}' \
+      https://api.github.com/repos/Rwanda-EMR/openmrs-module-rwandaprimarycare/dispatches
+```

--- a/pom.xml
+++ b/pom.xml
@@ -11,11 +11,23 @@
 	<url>http://openmrs.org</url>
 
 	<scm>
-		<connection>scm:git:https://github.com/PIH/openmrs-module-rwandaprimarycare/</connection>
-		<developerConnection>scm:git:https://github.com/PIH/openmrs-module-rwandaprimarycare/</developerConnection>
-		<url>https://github.com/PIH/openmrs-module-rwandaprimarycare/</url>
+		<developerConnection>scm:git:https://github.com/Rwanda-EMR/openmrs-module-rwandaprimarycare</developerConnection>
+		<url>https://github.com/Rwanda-EMR/openmrs-module-rwandaprimarycare</url>
 		<tag>HEAD</tag>
 	</scm>
+
+	<distributionManagement>
+		<repository>
+			<id>openmrs-repo-modules-rwandaemr</id>
+			<name>rwandaemr-artifactory-primary-0-releases</name>
+			<url>https://rwandaemr.jfrog.io/artifactory/libs-release</url>
+		</repository>
+		<snapshotRepository>
+			<id>openmrs-repo-modules-rwandaemr-snapshots</id>
+			<name>rwandaemr-artifactory-primary-0-snapshots</name>
+			<url>https://rwandaemr.jfrog.io/artifactory/libs-snapshot</url>
+		</snapshotRepository>
+	</distributionManagement>
 
 	<modules>
 		<module>api</module>
@@ -113,19 +125,6 @@
 		</dependency>
 
 	</dependencies>
-
-	<distributionManagement>
-		<repository>
-			<id>openmrs-repo-modules</id>
-			<name>OpenMRS Modules</name>
-			<url>http://mavenrepo.openmrs.org/nexus/content/repositories/modules</url>
-		</repository>
-		<snapshotRepository>
-			<id>openmrs-repo-snapshots</id>
-			<name>OpenMRS Snapshots</name>
-			<url>http://mavenrepo.openmrs.org/nexus/content/repositories/snapshots</url>
-		</snapshotRepository>
-	</distributionManagement>
 
 	<build>
 		<resources>


### PR DESCRIPTION
- Updated `distributionManagement` section of pom.xml

- Added `deploy-snapshot`, `perform-release` and `verify-prs` workflows

- Added `README.md` file