### PR TITLE
Up 129 - Support addressHierarchyRwanda tag

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -15,6 +15,13 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.openmrs.module</groupId>
+			<artifactId>htmlformentry-api</artifactId>
+			<type>jar</type>
+			<scope>provided</scope>
+			<version>${htmlformentryVersion}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.openmrs.module</groupId>
 			<artifactId>idgen-api</artifactId>
 			<type>jar</type>
 			<scope>provided</scope>

--- a/api/src/main/java/org/openmrs/module/rwandaprimarycare/RwandaPrimaryCareActivator.java
+++ b/api/src/main/java/org/openmrs/module/rwandaprimarycare/RwandaPrimaryCareActivator.java
@@ -21,81 +21,31 @@ import org.openmrs.EncounterRole;
 import org.openmrs.EncounterType;
 import org.openmrs.Privilege;
 import org.openmrs.VisitType;
-import org.openmrs.api.APIException;
-import org.openmrs.api.EncounterService;
-import org.openmrs.api.UserService;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.BaseModuleActivator;
-import org.openmrs.util.PrivilegeConstants;
+import org.openmrs.module.htmlformentry.HtmlFormEntryService;
+import org.openmrs.module.rwandaprimarycare.htmlformentry.handler.AddressHierarchyTagHandler;
 
 /**
  * This class contains the logic that is run every time this module
  * is either started or shutdown
  */
-public class RwandaPrimaryCareActivator extends BaseModuleActivator implements Runnable {
+public class RwandaPrimaryCareActivator extends BaseModuleActivator {
 
-	private Log log = LogFactory.getLog(this.getClass());
+	private final Log log = LogFactory.getLog(this.getClass());
 
 	/**
 	 * @see BaseModuleActivator#started()
 	 */
 	public void started() {
         log.info("Rwanda Primary Care Module started");
-        Thread contextChecker = new Thread(this);
-	    contextChecker.start();
-	    contextChecker = null;
-	}
-	
-	public final void run(){
-	    
-	       EncounterService es = null;
-	       UserService us = null;
-	       try {
-	            while (es == null || us == null) {
-	                Thread.sleep(30000);
-	                	if (RwandaPrimaryCareContextAware.getApplicationContext() != null){
-		                    try {
-		                        log.warn("RwandaPrimaryCare still waiting for app context and services to load...");
-		                        es = Context.getEncounterService();
-		                        us = Context.getUserService();
-		                    } catch (APIException apiEx){
-		                    	apiEx.printStackTrace();
-		                    }
-	                	}   
-	            }
-	        } catch (InterruptedException ex) {
-	        	ex.printStackTrace();
-	        }
-	        try {
-	            Thread.sleep(10000);
-	            // Start new OpenMRS session on this thread
-	            Context.openSession();
-	            Context.addProxyPrivilege(PrivilegeConstants.GET_ENCOUNTER_TYPES);
-	    	    Context.addProxyPrivilege(PrivilegeConstants.MANAGE_ENCOUNTER_TYPES);
-	    	    Context.addProxyPrivilege(PrivilegeConstants.MANAGE_PRIVILEGES);
-	    	    Context.addProxyPrivilege(PrivilegeConstants.GET_PRIVILEGES);
-	    	    Context.addProxyPrivilege("Manage Encounter Roles");
-	    	    Context.addProxyPrivilege("Get Visit Types");
-	    	    Context.addProxyPrivilege("Manage Visit Types");
-	    	    Context.addProxyPrivilege("Get Encounter Roles");
-	            addMetadata();
-	        } catch (Exception ex) {
-	            ex.printStackTrace();
-	            throw new RuntimeException("Could not pre-load rwanda primary care encounter types and privileges " + ex);
-	        } finally {
-		        Context.removeProxyPrivilege(PrivilegeConstants.GET_ENCOUNTER_TYPES);
-		        Context.removeProxyPrivilege(PrivilegeConstants.MANAGE_ENCOUNTER_TYPES);
-		        Context.removeProxyPrivilege(PrivilegeConstants.MANAGE_PRIVILEGES);
-		        Context.removeProxyPrivilege(PrivilegeConstants.GET_PRIVILEGES);
-		        Context.removeProxyPrivilege("Manage Encounter Roles");
-		        Context.removeProxyPrivilege("Get Visit Types");
-		        Context.removeProxyPrivilege("Manage Visit Types");
-		        Context.removeProxyPrivilege("Get Encounter Roles");
-	            es = null;
-		        us = null;
-	            Context.closeSession();
-	            log.info("RwandaPrimaryCare loaded  metadata successfully.");
-	        }   
+
+        log.info("Registering tag with htmlformentry");
+        HtmlFormEntryService hfes = Context.getService(HtmlFormEntryService.class);
+		hfes.addHandler("addressHierarchyRwanda", new AddressHierarchyTagHandler());
+
+		log.info("Registering required metadata");
+		addMetadata();
 	}
 	
 	/**
@@ -105,9 +55,7 @@ public class RwandaPrimaryCareActivator extends BaseModuleActivator implements R
 		log.info("Rwanda Primary Care Module stopped");
 	}
 	
-	
-	
-	
+
 	public void addMetadata(){
 		 {
      		EncounterType et = Context.getEncounterService().getEncounterType("Registration");
@@ -198,7 +146,5 @@ public class RwandaPrimaryCareActivator extends BaseModuleActivator implements R
              }
              PrimaryCareConstants.VISIT_TYPE_OUTPATIENT = vt;
          }
-         
 	}
-	
 }

--- a/api/src/main/java/org/openmrs/module/rwandaprimarycare/htmlformentry/element/AddressHierarchySubmissionElement.java
+++ b/api/src/main/java/org/openmrs/module/rwandaprimarycare/htmlformentry/element/AddressHierarchySubmissionElement.java
@@ -200,52 +200,41 @@ public class AddressHierarchySubmissionElement implements HtmlGeneratorElement,
 	 */
 	private boolean currentAddressEqualsNewAddress(FormEntryContext context, HttpServletRequest request,
 	                                               PersonAddress currentAddress) {
-		
-		boolean equals = true;
+
 		if (currentAddress == null) {
 			return false;
 		}
+		boolean equals = true;
 	    for (Widget widget: addressWidgetList) {
 			AddressHierarchyWidget addressWidget =(AddressHierarchyWidget)widget;
 			if (addressWidget.getType().equals(AddressHierarchyWidget.TYPE_COUNTRY)) {
-				if (currentAddress.getCountry()!=null && !currentAddress.getCountry().trim().equalsIgnoreCase(request.getParameter(context.getFieldName(addressWidget)).trim())) {
-					equals = false;
-					break;
-				}
+				equals = equals && addressMatches(currentAddress.getCountry(), addressWidget, context, request);
 			}
 			if (addressWidget.getType().equals(AddressHierarchyWidget.TYPE_PROVINCE)) {
-				if (currentAddress.getStateProvince()!=null && !currentAddress.getStateProvince().trim().equalsIgnoreCase(request.getParameter(context.getFieldName(addressWidget)).trim())) {
-					equals = false;
-					break;
-				}
+				equals = equals && addressMatches(currentAddress.getStateProvince(), addressWidget, context, request);
 			}
 			if (addressWidget.getType().equals(AddressHierarchyWidget.TYPE_DISTRICT)) {
-				if (currentAddress.getCountyDistrict()!=null && !currentAddress.getCountyDistrict().trim().equalsIgnoreCase(request.getParameter(context.getFieldName(addressWidget)).trim())) {
-					equals = false;
-					break;
-				}
+				equals = equals && addressMatches(currentAddress.getCountyDistrict(), addressWidget, context, request);
 			}
 			if (addressWidget.getType().equals(AddressHierarchyWidget.TYPE_SECTOR)) {
-				if (currentAddress.getCityVillage()!=null && !currentAddress.getCityVillage().trim().equalsIgnoreCase(request.getParameter(context.getFieldName(addressWidget)).trim())) {
-					equals = false;
-					break;
-				}
+				equals = equals && addressMatches(currentAddress.getCityVillage(), addressWidget, context, request);
 			}
 			if (addressWidget.getType().equals(AddressHierarchyWidget.TYPE_CELL)) {
-				if (currentAddress.getAddress3()!=null && !currentAddress.getAddress3().trim().equalsIgnoreCase(request.getParameter(context.getFieldName(addressWidget)).trim())) {
-					equals = false;
-					break;
-				}
+				equals = equals && addressMatches(currentAddress.getAddress3(), addressWidget, context, request);
 			}
 			if (addressWidget.getType().equals(AddressHierarchyWidget.TYPE_UMUDUGUDU)) {
-				if (currentAddress.getAddress1()!=null && !currentAddress.getAddress1().trim().equalsIgnoreCase(request.getParameter(context.getFieldName(addressWidget)).trim())) {
-					equals = false;
-					break;
-				}
+				equals = equals && addressMatches(currentAddress.getAddress1(), addressWidget, context, request);
 			}
         }
 		
 	    return equals;
+    }
+
+    protected boolean addressMatches(String oldVal, Widget widget, FormEntryContext context, HttpServletRequest request) {
+		String newVal = request.getParameter(context.getFieldName(widget));
+	    oldVal = (oldVal == null ? "" : oldVal.trim());
+	    newVal = (newVal == null ? "" : newVal.trim());
+		return newVal.equalsIgnoreCase(oldVal);
     }
 	
 	protected void registerWidgetList(List<Widget> widgetList, FormEntryContext context) {

--- a/api/src/main/java/org/openmrs/module/rwandaprimarycare/htmlformentry/element/AddressHierarchySubmissionElement.java
+++ b/api/src/main/java/org/openmrs/module/rwandaprimarycare/htmlformentry/element/AddressHierarchySubmissionElement.java
@@ -1,0 +1,257 @@
+/**
+ * The contents of this file are subject to the OpenMRS Public License
+ * Version 1.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * http://license.openmrs.org
+ *
+ * Software distributed under the License is distributed on an "AS IS"
+ * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
+ * License for the specific language governing rights and limitations
+ * under the License.
+ *
+ * Copyright (C) OpenMRS, LLC.  All Rights Reserved.
+ */
+package org.openmrs.module.rwandaprimarycare.htmlformentry.element;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.StringTokenizer;
+import java.util.UUID;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.openmrs.Patient;
+import org.openmrs.PersonAddress;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.htmlformentry.FormEntryContext;
+import org.openmrs.module.htmlformentry.FormEntryContext.Mode;
+import org.openmrs.module.htmlformentry.FormEntrySession;
+import org.openmrs.module.htmlformentry.FormSubmissionError;
+import org.openmrs.module.htmlformentry.action.FormSubmissionControllerAction;
+import org.openmrs.module.htmlformentry.element.HtmlGeneratorElement;
+import org.openmrs.module.htmlformentry.widget.ErrorWidget;
+import org.openmrs.module.htmlformentry.widget.Widget;
+import org.openmrs.module.rwandaprimarycare.htmlformentry.widget.AddressHierarchyWidget;
+import org.openmrs.web.WebConstants;
+
+/**
+ * Holds a list of widgets which represent the address hierarchy, and serves as both the HtmlGeneratorElement 
+ * and the FormSubmissionControllerAction
+ */
+public class AddressHierarchySubmissionElement implements HtmlGeneratorElement,
+		FormSubmissionControllerAction {
+
+	protected final Log log = LogFactory.getLog(AddressHierarchySubmissionElement.class);
+	
+	public static final String FIELD_TYPES = "types";
+	
+	private List<Widget> addressWidgetList;
+	private ErrorWidget errorWidget = null;
+    
+	public AddressHierarchySubmissionElement(FormEntryContext context, HttpServletRequest request,
+	    Map<String, String> parameters) {
+		Patient existingPatient = context.getExistingPatient();
+		addressWidgetList = new ArrayList<Widget>();
+		errorWidget = new ErrorWidget();
+		
+		// check parameter types (optional)
+		String types = parameters.get(FIELD_TYPES);
+		if (types != null && types.length() > 1) {
+			StringTokenizer  tokenizer = new StringTokenizer(types, ",");
+			while (tokenizer.hasMoreElements()) {
+				String element = ((String) tokenizer.nextElement()).trim();
+				if (element.equalsIgnoreCase(AddressHierarchyWidget.TYPE_COUNTRY)
+				        || element.equalsIgnoreCase(AddressHierarchyWidget.TYPE_PROVINCE)
+				        || element.equalsIgnoreCase(AddressHierarchyWidget.TYPE_DISTRICT)
+				        || element.equalsIgnoreCase(AddressHierarchyWidget.TYPE_SECTOR)
+				        || element.equalsIgnoreCase(AddressHierarchyWidget.TYPE_CELL)
+				        || element.equalsIgnoreCase(AddressHierarchyWidget.TYPE_UMUDUGUDU)) {
+					addressWidgetList.add(new AddressHierarchyWidget(element, existingPatient.getPersonAddress()));
+				} else {
+					throw new IllegalArgumentException("You must provide a valid type for example country in " + parameters);
+				}
+            }
+		} else {
+			addressWidgetList.add(new AddressHierarchyWidget(AddressHierarchyWidget.TYPE_COUNTRY, existingPatient.getPersonAddress()));
+			addressWidgetList.add(new AddressHierarchyWidget(AddressHierarchyWidget.TYPE_PROVINCE, existingPatient.getPersonAddress()));
+			addressWidgetList.add(new AddressHierarchyWidget(AddressHierarchyWidget.TYPE_DISTRICT, existingPatient.getPersonAddress()));
+			addressWidgetList.add(new AddressHierarchyWidget(AddressHierarchyWidget.TYPE_SECTOR, existingPatient.getPersonAddress()));
+			addressWidgetList.add(new AddressHierarchyWidget(AddressHierarchyWidget.TYPE_CELL, existingPatient.getPersonAddress()));
+			addressWidgetList.add(new AddressHierarchyWidget(AddressHierarchyWidget.TYPE_UMUDUGUDU, existingPatient.getPersonAddress()));
+		}
+
+		// Register widgets
+		registerWidgetList(addressWidgetList, context);
+		context.registerWidget(errorWidget);
+	}
+
+	/**
+	 * @should return HTML snippet
+	 * @see org.openmrs.module.htmlformentry.element.HtmlGeneratorElement#generateHtml(org.openmrs.module.htmlformentry.FormEntryContext)
+	 */
+	public String generateHtml(FormEntryContext context) {
+		StringBuilder ret = new StringBuilder();
+		
+		ret.append("<script type=\"text/javascript\" src=\"/" + WebConstants.WEBAPP_NAME
+		        + "/moduleResources/rwandaprimarycare/AddressHierarchy.js\"></script>");
+		if (context.getMode() != Mode.VIEW) {
+			ret.append(errorWidget.generateHtml(context));
+		}
+		ret.append("<table class=\"tableClass\"><tbody>");
+		
+		for (Widget widget : addressWidgetList) {
+			AddressHierarchyWidget addressWidget =(AddressHierarchyWidget)widget;
+			if (addressWidget != null) {
+				ret.append("<tr>");
+				ret.append(addressWidget.generateHtml(context));		
+				ret.append("</tr>");
+			}	        
+        }
+
+		ret.append("<tr><td>Structured:</td><td><span class=\"isstructured\" id=\"structured_\">--</span></td></tr></tbody></table>");
+		
+		return ret.toString();
+	}
+
+	/**
+	 * handleSubmission modifies person address 
+	 * @see org.openmrs.module.htmlformentry.action.FormSubmissionControllerAction#handleSubmission(org.openmrs.module.htmlformentry.FormEntrySession, HttpServletRequest)
+	 */
+	public void handleSubmission(FormEntrySession session, HttpServletRequest request) {
+		Patient patient = (Patient) session.getSubmissionActions().getCurrentPerson();
+
+		if (patient == null) {
+			throw new RuntimeException("Person shouldn't be null");
+		}
+
+		FormEntryContext context = session.getContext();
+		if (context.getMode() != Mode.VIEW) {
+
+			PersonAddress currentAddress = patient.getPersonAddress();
+			//  validate if current address equals new address
+			if (currentAddressEqualsNewAddress(context, request, currentAddress)) {
+				log.info("current address equals new address, no entities will be changed");
+			} else {
+				PersonAddress personAddress = new PersonAddress();
+				Date today = new Date();
+				personAddress.setDateCreated(today);
+				personAddress.setCreator(Context.getAuthenticatedUser());
+				if (personAddress.getUuid() == null)
+					personAddress.setUuid(UUID.randomUUID().toString());
+				for (Widget widget : addressWidgetList) {
+					AddressHierarchyWidget addressWidget =(AddressHierarchyWidget)widget;
+
+					if (addressWidget.getType().equals(AddressHierarchyWidget.TYPE_COUNTRY)) {
+						personAddress.setCountry(request.getParameter(context.getFieldName(addressWidget)).trim());
+					}
+					if (addressWidget.getType().equals(AddressHierarchyWidget.TYPE_PROVINCE)) {
+						personAddress.setStateProvince(request.getParameter(context.getFieldName(addressWidget)).trim());
+					}
+					if (addressWidget.getType().equals(AddressHierarchyWidget.TYPE_DISTRICT)) {
+						personAddress.setCountyDistrict(request.getParameter(context.getFieldName(addressWidget)).trim());
+					}
+					if (addressWidget.getType().equals(AddressHierarchyWidget.TYPE_SECTOR)) {
+						personAddress.setCityVillage(request.getParameter(context.getFieldName(addressWidget)).trim());
+					}
+					if (addressWidget.getType().equals(AddressHierarchyWidget.TYPE_CELL)) {
+						personAddress.setAddress3(request.getParameter(context.getFieldName(addressWidget)).trim());
+					}
+					if (addressWidget.getType().equals(AddressHierarchyWidget.TYPE_UMUDUGUDU)) {
+						personAddress.setAddress1(request.getParameter(context.getFieldName(addressWidget)).trim());
+					}
+				}
+				if (currentAddress != null) {
+					currentAddress.setPreferred(false);
+					currentAddress.setVoided(true);
+					currentAddress.setVoidedBy(Context.getAuthenticatedUser());
+					currentAddress.setDateVoided(today);
+					currentAddress.setDateChanged(today);
+					currentAddress.setChangedBy(Context.getAuthenticatedUser());
+				}
+				personAddress.setPreferred(true);
+				patient.addAddress(personAddress);
+				log.info("new address added to patient " + personAddress);
+			}
+		}
+	}
+
+	/**
+	 * @should return validation errors
+	 * @see org.openmrs.module.htmlformentry.action.FormSubmissionControllerAction#validateSubmission(org.openmrs.module.htmlformentry.FormEntryContext,
+	 *      HttpServletRequest)
+	 */
+	public Collection<FormSubmissionError> validateSubmission(FormEntryContext context, HttpServletRequest request) {
+		List<FormSubmissionError> ret = new ArrayList<FormSubmissionError>();
+		return ret;
+	}
+
+
+	/**
+	 * Returns if current address equals new address
+	 * 
+	 * @param context
+	 * @param request
+	 * @param currentAddress
+	 * @return true if current address equals new address
+	 */
+	private boolean currentAddressEqualsNewAddress(FormEntryContext context, HttpServletRequest request,
+	                                               PersonAddress currentAddress) {
+		
+		boolean equals = true;
+		if (currentAddress == null) {
+			return false;
+		}
+	    for (Widget widget: addressWidgetList) {
+			AddressHierarchyWidget addressWidget =(AddressHierarchyWidget)widget;
+			if (addressWidget.getType().equals(AddressHierarchyWidget.TYPE_COUNTRY)) {
+				if (currentAddress.getCountry()!=null && !currentAddress.getCountry().trim().equalsIgnoreCase(request.getParameter(context.getFieldName(addressWidget)).trim())) {
+					equals = false;
+					break;
+				}
+			}
+			if (addressWidget.getType().equals(AddressHierarchyWidget.TYPE_PROVINCE)) {
+				if (currentAddress.getStateProvince()!=null && !currentAddress.getStateProvince().trim().equalsIgnoreCase(request.getParameter(context.getFieldName(addressWidget)).trim())) {
+					equals = false;
+					break;
+				}
+			}
+			if (addressWidget.getType().equals(AddressHierarchyWidget.TYPE_DISTRICT)) {
+				if (currentAddress.getCountyDistrict()!=null && !currentAddress.getCountyDistrict().trim().equalsIgnoreCase(request.getParameter(context.getFieldName(addressWidget)).trim())) {
+					equals = false;
+					break;
+				}
+			}
+			if (addressWidget.getType().equals(AddressHierarchyWidget.TYPE_SECTOR)) {
+				if (currentAddress.getCityVillage()!=null && !currentAddress.getCityVillage().trim().equalsIgnoreCase(request.getParameter(context.getFieldName(addressWidget)).trim())) {
+					equals = false;
+					break;
+				}
+			}
+			if (addressWidget.getType().equals(AddressHierarchyWidget.TYPE_CELL)) {
+				if (currentAddress.getAddress3()!=null && !currentAddress.getAddress3().trim().equalsIgnoreCase(request.getParameter(context.getFieldName(addressWidget)).trim())) {
+					equals = false;
+					break;
+				}
+			}
+			if (addressWidget.getType().equals(AddressHierarchyWidget.TYPE_UMUDUGUDU)) {
+				if (currentAddress.getAddress1()!=null && !currentAddress.getAddress1().trim().equalsIgnoreCase(request.getParameter(context.getFieldName(addressWidget)).trim())) {
+					equals = false;
+					break;
+				}
+			}
+        }
+		
+	    return equals;
+    }
+	
+	protected void registerWidgetList(List<Widget> widgetList, FormEntryContext context) {
+		for (Widget widget : widgetList) {
+			context.registerWidget(widget);
+        }
+	}
+
+}

--- a/api/src/main/java/org/openmrs/module/rwandaprimarycare/htmlformentry/handler/AddressHierarchyTagHandler.java
+++ b/api/src/main/java/org/openmrs/module/rwandaprimarycare/htmlformentry/handler/AddressHierarchyTagHandler.java
@@ -1,0 +1,45 @@
+/**
+ * The contents of this file are subject to the OpenMRS Public License
+ * Version 1.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * http://license.openmrs.org
+ *
+ * Software distributed under the License is distributed on an "AS IS"
+ * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
+ * License for the specific language governing rights and limitations
+ * under the License.
+ *
+ * Copyright (C) OpenMRS, LLC.  All Rights Reserved.
+ */
+package org.openmrs.module.rwandaprimarycare.htmlformentry.handler;
+
+import java.util.Map;
+
+import org.openmrs.module.htmlformentry.FormEntrySession;
+import org.openmrs.module.htmlformentry.FormSubmissionController;
+import org.openmrs.module.htmlformentry.handler.SubstitutionTagHandler;
+import org.openmrs.module.rwandaprimarycare.htmlformentry.element.AddressHierarchySubmissionElement;
+
+/**
+ * Handles the {@code <addressHierarchyRwanda>} tag <br/>
+ * Usage: <br/>
+ * - default <addressHierarchyRwanda /> shows all Rwanda relevant input fields <br/>
+ * - to change the default add the types parameter e.g. <addressHierarchyRwanda types="country" /> <br/>
+ * - this tag will include the script tag for AddressHierarchy.js
+ * 
+ * <br/> In OpenMRS 1.9 the tag could be moved to HTMLFormEntry module, see http://tickets.openmrs.org/browse/TRUNK-1924
+ */
+public class AddressHierarchyTagHandler extends SubstitutionTagHandler {
+	
+	@Override
+	protected String getSubstitution(FormEntrySession session, FormSubmissionController controller,
+	                                 Map<String, String> parameters) {
+		
+		AddressHierarchySubmissionElement element = new AddressHierarchySubmissionElement(session.getContext(),
+		        controller.getLastSubmission(), parameters);
+		session.getSubmissionController().addAction(element);
+		
+		return element.generateHtml(session.getContext());
+	}
+	
+}

--- a/api/src/main/java/org/openmrs/module/rwandaprimarycare/htmlformentry/widget/AddressHierarchyWidget.java
+++ b/api/src/main/java/org/openmrs/module/rwandaprimarycare/htmlformentry/widget/AddressHierarchyWidget.java
@@ -1,0 +1,136 @@
+/**
+ * The contents of this file are subject to the OpenMRS Public License
+ * Version 1.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * http://license.openmrs.org
+ *
+ * Software distributed under the License is distributed on an "AS IS"
+ * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
+ * License for the specific language governing rights and limitations
+ * under the License.
+ *
+ * Copyright (C) OpenMRS, LLC.  All Rights Reserved.
+ */
+package org.openmrs.module.rwandaprimarycare.htmlformentry.widget;
+
+import org.openmrs.PersonAddress;
+import org.openmrs.api.context.Context;
+import org.openmrs.messagesource.MessageSourceService;
+import org.openmrs.module.htmlformentry.FormEntryContext;
+import org.openmrs.module.htmlformentry.FormEntryContext.Mode;
+import org.openmrs.module.htmlformentry.widget.TextFieldWidget;
+
+/**
+ * AddressHierarchyWidget adds a CSS class and a select input field which will interact with
+ * the textfield
+ */
+public class AddressHierarchyWidget extends TextFieldWidget {
+
+    public static final String TYPE_UMUDUGUDU = "Umudugudu";
+    public static final String TYPE_CELL = "Cell";
+    public static final String TYPE_SECTOR = "Sector";
+    public static final String TYPE_DISTRICT = "District";
+    public static final String TYPE_PROVINCE = "Province";
+    public static final String TYPE_COUNTRY = "Country";
+
+    private String type;
+	
+	/**
+	 * @param type
+	 * @param personAddress
+	 * @should set type and initial Value
+	 */
+	public AddressHierarchyWidget(String type, PersonAddress personAddress) {
+		this.type = type;
+		
+		if (personAddress != null) {
+			if (type.equalsIgnoreCase(TYPE_COUNTRY)) {
+				setInitialValue(personAddress.getCountry());
+			} else if (type.equalsIgnoreCase(TYPE_PROVINCE)) {
+				setInitialValue(personAddress.getStateProvince());
+			} else if (type.equalsIgnoreCase(TYPE_DISTRICT)) {
+				setInitialValue(personAddress.getCountyDistrict());
+			} else if (type.equalsIgnoreCase(TYPE_SECTOR)) {
+				setInitialValue(personAddress.getCityVillage());
+			} else if (type.equalsIgnoreCase(TYPE_CELL)) {
+				setInitialValue(personAddress.getAddress3());
+			} else if (type.equalsIgnoreCase(TYPE_UMUDUGUDU)) {
+				setInitialValue(personAddress.getAddress1());
+			}
+		}
+	}
+	
+	/**
+	 * @should return HTML snippet
+	 * @see org.openmrs.module.htmlformentry.element.HtmlGeneratorElement#generateHtml(org.openmrs.module.htmlformentry.FormEntryContext)
+	 */
+	public String generateHtml(FormEntryContext context) {
+		StringBuilder sb = new StringBuilder();
+		MessageSourceService mss = Context.getMessageSourceService();
+		String inputCssClass = "";
+		String selectCssClass = "";
+		String selectName = "";
+			
+		if (getInitialValue() == null)
+			setInitialValue("");
+		
+		sb.append("<td>");
+		if (type.equalsIgnoreCase(TYPE_COUNTRY)) {
+			sb.append(mss.getMessage("Location.country") + "</td>");
+			 inputCssClass = "countrySaveClass";
+			 selectCssClass = "countryClass";
+			 selectName = "countryselect";
+		} else if (type.equalsIgnoreCase(TYPE_PROVINCE)) {
+			sb.append(mss.getMessage("Location.stateProvince") + "</td>");
+			 inputCssClass = "provinceSaveClass";
+			 selectCssClass = "provinceClass";
+			 selectName = "stateProvinceselect";
+		} else if (type.equalsIgnoreCase(TYPE_DISTRICT)) {
+			sb.append(mss.getMessage("Location.district") + "</td>");
+			 inputCssClass = "districtSaveClass";
+			 selectCssClass = "districtClass";
+			 selectName = "countryDistrictselect";
+		} else if (type.equalsIgnoreCase("sector")) {
+			sb.append(mss.getMessage("Location.cityVillage") + "</td>");
+			 inputCssClass = "sectorSaveClass";
+			 selectCssClass = "sectorClass";
+			 selectName = "cityVillageselect";
+		} else if (type.equalsIgnoreCase("cell")) {
+			sb.append(mss.getMessage("Location.cell") + "</td>");
+			 inputCssClass = "cellSaveClass";
+			 selectCssClass = "cellClass";
+			 selectName = "cellselect";
+		} else if (type.equalsIgnoreCase(TYPE_UMUDUGUDU)) {
+			sb.append(mss.getMessage("Location.rwandanNeighborhood") + "</td>");
+			 inputCssClass = "address1SaveClass";
+			 selectCssClass = "address1Class";
+			 selectName = "address1select";
+		}		
+
+		if (context.getMode().equals(Mode.VIEW)) {
+			// hidden input field is included just to make the structured icon work (see AddressHierarchy.js)
+			sb.append("<td><input type=\"hidden\" class=\"" + inputCssClass + "\" value=\"" + super.getInitialValue()
+			        + "\"/>" + super.getInitialValue() + "</td>");
+		} else {
+			sb.append("<td><input type=\"text\" name=\"" + context.getFieldName(this) + "\"	value=\"" + getInitialValue().trim()
+			        + " \" 	class=\"" + inputCssClass + "\" />" + "</td>	<td><select name=\""
+			        + selectName + "\" class=\"" + selectCssClass + "\"></select></td>");
+		}
+		return sb.toString();
+	}
+	
+    /**
+     * @return the type
+     */
+    public String getType() {
+    	return type;
+    }
+
+	
+    /**
+     * @param type the type to set
+     */
+    public void setType(String type) {
+    	this.type = type;
+    }
+}

--- a/omod/src/main/java/org/openmrs/module/rwandaprimarycare/HtmlFormEntryAddressHierarchyController.java
+++ b/omod/src/main/java/org/openmrs/module/rwandaprimarycare/HtmlFormEntryAddressHierarchyController.java
@@ -1,0 +1,233 @@
+package org.openmrs.module.rwandaprimarycare;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.OutputStreamWriter;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.openmrs.Patient;
+import org.openmrs.PersonAddress;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.addresshierarchy.AddressHierarchyEntry;
+import org.openmrs.module.addresshierarchy.AddressHierarchyLevel;
+import org.openmrs.module.addresshierarchy.AddressValidator;
+import org.openmrs.module.addresshierarchy.service.AddressHierarchyService;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.ServletRequestUtils;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Controller
+public class HtmlFormEntryAddressHierarchyController {
+	protected final Log log = LogFactory.getLog(getClass());
+
+	/**
+	 * Gets the addresses for the patient specified in the patientId request parameter.
+	 * {
+	 * 	 "results": 2,
+	 * 	 "rows": [
+	 *     { "id": 1, "firstname": "Bill", occupation: "Gardener" },         // a row object
+	 *     { "id": 2, "firstname": "Ben" , occupation: "Horticulturalist" }  // another row object
+	 * 	 ]
+	 * }
+	 *
+	 */
+	@RequestMapping("/module/rwandaprimarycare/patientAddress.form")
+	protected void patientAddress(HttpServletRequest request, HttpServletResponse response,
+			@RequestParam("patientId") Integer patientId) throws Exception {
+		Set<PersonAddress> addressSet = null;
+		Map<String, Set<PersonAddress>> map = new HashMap<String,Set<PersonAddress>>();
+
+		Patient patient = Context.getPatientService().getPatient(patientId);
+		if (patient != null) {
+			addressSet = patient.getAddresses();
+			map.put("1", addressSet);
+
+			Collection<Set<PersonAddress>> addressList = map.values();
+			PersonAddress pa = null;
+			AddressValidator av = new AddressValidator();
+			StringBuffer sb = new StringBuffer();
+			sb.append("{");
+			Iterator<Set<PersonAddress>> setIterator= addressList.iterator();
+			Iterator<PersonAddress> addressIterator = null;
+			if(setIterator.hasNext()){
+				addressIterator = setIterator.next().iterator();
+			}
+			sb.append("\"addresses\":");
+			sb.append("[");
+			while(addressIterator != null && addressIterator.hasNext()){
+				sb.append("{");
+				pa = addressIterator.next();
+				if (pa != null) {
+					sb.append("\"structured\":");
+					sb.append("\""+av.isAddressStructured(pa)+"\"");
+					sb.append(",");
+
+					sb.append("\"country\":");
+					sb.append("\""+pa.getCountry()+"\"");
+					sb.append(",");
+
+					sb.append("\"stateProvince\":");
+					sb.append("\""+pa.getStateProvince()+"\"");
+					sb.append(",");
+
+					sb.append("\"countyDistrict\":");
+					sb.append("\""+pa.getCountyDistrict()+"\"");
+					sb.append(",");
+
+					sb.append("\"cityVillage\":");
+					sb.append("\""+pa.getCityVillage()+"\"");
+					sb.append(",");
+
+					sb.append("\"address3\":");
+					sb.append("\""+pa.getAddress3()+"\"");
+					sb.append(",");
+
+					sb.append("\"address1\":");
+					sb.append("\""+pa.getAddress1()+"\"");
+					sb.append("");
+
+					sb.append("}");
+					if(addressIterator.hasNext()){
+						sb.append(",");
+					}
+				}
+			}
+			sb.append("]");
+
+			sb.append("}");
+
+			response.setContentType("text/html");
+			OutputStreamWriter osw = new OutputStreamWriter(response.getOutputStream());
+			osw.write(sb.toString());
+			osw.flush();
+		}
+	}
+
+	@RequestMapping("/module/rwandaprimarycare/locations.form")
+	protected void locations(HttpServletRequest request, HttpServletResponse response,
+			@RequestParam(value = "locationId", required = false) Integer locationId) throws Exception {
+
+		AddressHierarchyService ahs = Context.getService(AddressHierarchyService.class);
+		List<AddressHierarchyEntry> locationList;
+
+		if (locationId == null || locationId == -1){
+			locationList = ahs.getTopOfHierarchyList();
+		}
+		else {
+			locationList = ahs.getNextComponent(locationId);
+		}
+
+		Map<String, List<AddressHierarchyEntry>> map = new HashMap<String,List<AddressHierarchyEntry>>();
+		map.put(Integer.toString(1), locationList);
+
+		AddressHierarchyEntry ah = null;
+
+		StringBuffer sb = new StringBuffer();
+		sb.append("{");
+		if (map.values().iterator().hasNext()){
+			List<AddressHierarchyEntry> currList = map.values().iterator().next();
+			sb.append("\"addresses\":");
+			sb.append("[");
+			Iterator<AddressHierarchyEntry> locIterator = currList.iterator();
+			while(locIterator.hasNext()){
+				sb.append("{");
+				ah = locIterator.next();
+
+				sb.append("\"id\":");
+				String idString = "";
+				Integer tempId = -1;
+				tempId = ah.getAddressHierarchyEntryId();
+				if(tempId!=null && tempId != -1){
+					idString = tempId.toString();
+
+				}
+				sb.append("\""+idString+"\"");
+				sb.append(",");
+
+				sb.append("\"type\":");
+				AddressHierarchyLevel type = ah.getLevel();
+				String typeName = "";
+				if(type!=null){
+					typeName = type.getName();
+				}
+				sb.append("\""+typeName+"\"");
+				sb.append(",");
+
+				String childTypeName = "";
+				AddressHierarchyLevel tempChildType = ahs.getChildAddressHierarchyLevel(type);
+				if(tempChildType != null){
+					childTypeName = tempChildType.getName();
+				}
+				sb.append("\"childType\":");
+				sb.append("\""+childTypeName+"\"");
+				sb.append(",");
+				sb.append("\"display\":");
+				sb.append("\""+ah.getLocationName()+"\"");
+				sb.append("}");
+				if(locIterator.hasNext()){
+					sb.append(",");
+				}
+			}
+			sb.append("]");
+		}
+		sb.append("}");
+
+		response.setContentType("text/html");
+		OutputStreamWriter osw = new OutputStreamWriter(response.getOutputStream());
+		osw.write(sb.toString());
+		osw.flush();
+	}
+
+	@RequestMapping("/module/rwandaprimarycare/ahValidateAddress.form")
+	public void ahValidateAddress(HttpServletRequest request, HttpServletResponse response) throws Exception {
+		PersonAddress pa = new PersonAddress();
+
+		pa.setCountry(ServletRequestUtils.getStringParameter(request, "country", null).trim());
+		pa.setStateProvince(ServletRequestUtils.getStringParameter(request, "province", null).trim());
+		pa.setCountyDistrict(ServletRequestUtils.getStringParameter(request, "district", null).trim());
+		pa.setCityVillage(ServletRequestUtils.getStringParameter(request, "sector", null).trim());
+		pa.setAddress3(ServletRequestUtils.getStringParameter(request, "cell", null).trim());
+		pa.setAddress1(ServletRequestUtils.getStringParameter(request, "umudugudu", null).trim());
+		boolean validity = new AddressValidator().isAddressStructured(pa);
+
+		HashMap<String, Integer> validityMap = new HashMap<String, Integer>();
+		if (validity) {
+			validityMap.put("1", 1);
+		} else {
+			validityMap.put("1", 0);
+		}
+
+		Collection<Integer> list = validityMap.values();
+
+		StringBuffer sb = new StringBuffer();
+		sb.append("{");
+		sb.append("\"values\":");
+		sb.append("[");
+		int  lastPass = list.size()-1;
+		int count = 0;
+		for(Integer i:list) {
+			sb.append("{");
+			sb.append("\"value\":");
+			sb.append("\"" + i + "\"");
+			sb.append("}");
+			if (lastPass > count)
+				sb.append(",");
+			count++;
+		}
+		sb.append("]");
+		sb.append("}");
+
+		response.setContentType("text/html");
+		OutputStreamWriter osw = new OutputStreamWriter(response.getOutputStream());
+		osw.write(sb.toString());
+		osw.flush();
+	}
+}

--- a/omod/src/main/webapp/resources/AddressHierarchy.js
+++ b/omod/src/main/webapp/resources/AddressHierarchy.js
@@ -1,0 +1,311 @@
+$j = jQuery.noConflict();
+
+
+function getPatientAddress(patientId) {
+	$j.getJSON(openmrsContextPath  + "/module/rwandaprimarycare/patientAddress.form", {
+		patientId :patientId
+	}, function(data) {
+		var count = -1;
+		$j.each(data.addresses, function(i, address) {
+			count++;
+			$j("#cnt_" + count).val(address.country);
+			$j("#sp_" + count).val(address.stateProvince);
+			$j("#cd_" + count).val(address.countyDistrict);
+			$j("#cv_" + count).val(address.cityVillage);
+			$j("#nc_" + count).val(address.address3);
+			$j("#a1_" + count).val(address.address1);
+			$j("#structured_" + count).text(address.structured);
+		});
+
+	});
+}
+
+//this is a hack for google chrome, for which :hidden selector doesn't work...
+function isVisible(a){
+	//this block is a hack for google chrome.  
+	for (var i = 0 ; i < $j(a).parents().size(); i++){
+		var x = $j(a).parents()[i];
+		//if ($j(x).hasClass("tabBox") || ( $j(x).attr("id", "addressPortlet") && $j(x).is("div")) ){
+			var style = new String($j(x).attr("style"));
+			if (style.indexOf("display") > -1 && style.indexOf("none") > -1){
+				return false;
+			}
+		//}
+	}
+	return true;
+}
+
+function changeLocation(parentLocationId, nextElement) {
+	var locIdString = "" + parentLocationId;
+	var parsedParentLocationId = locIdString.substring(3);
+	$j.getJSON(openmrsContextPath  + "/module/rwandaprimarycare/locations.form", {
+		locationId :parsedParentLocationId
+	}, function(data) {
+		var options = "<option value='--'>--</option>";
+		$j.each(data.addresses, function(i, address) {
+			options += "<option value='ah_" + address.id  + "' id = '" + address.id +"'>"+address.display+"</option>";
+		});
+		$j(nextElement).append(options);
+		
+		if ($j(nextElement).attr('class') != undefined){
+			if (getSiblingWithinValueFromClass(nextElement,$j(nextElement).attr('class').replace("Class","SaveClass"))){
+				
+				//set selected value 
+				var textBoxValue = getSiblingWithinValueFromClass($j(nextElement),$j(nextElement).attr('class').replace("Class","SaveClass"));
+				textBoxValue = new String(textBoxValue);
+				var op = $j(nextElement).children('option').filter(function() {
+					if (($j(this).text().trim() + "") == textBoxValue && $j(this).val() != "--" && isVisible(this)) {  //hidden works in firefox, fails in chrome && !$j(this).is(":hidden")
+				    	return this;
+				    }
+				});
+				$j(op[0]).attr("selected", "selected");
+				var list = $j(nextElement).find("option:selected").filter(function(){
+					if ($j(this).val() != '--' && isVisible(this) ) return this;  //same chrome problem
+				});
+				if ($j(list).text() == getSiblingWithinValueFromClass($j(nextElement),$j(nextElement).attr('class').replace("Class","SaveClass"))){
+					var nextSelect = findNextSelect(nextElement);
+					if (nextSelect != null)
+						setTimeout(function() {changeLocation($j(nextElement).val(),$j(nextSelect))}, 10);
+				}
+			}
+		}	
+	});
+}
+
+function findNextSelect(nextElement){
+	var inputs = $j(nextElement).closest("table:visible").find(':input:visible');
+	var winningPos = null;
+	for (var i = 0; i < inputs.length - 2; i++){
+		if ($j(inputs[i]).attr("name") == $j(nextElement).attr("name")){
+			winningPos = i + 2;
+			break;
+		}	
+	}
+	if (winningPos != null)
+		return $j(inputs[winningPos]);
+}
+
+
+function validateSingleAddress(someElement,country, province, district, sector, cell, umudugudu, targetElement){
+	//alert(country + province + district + sector + cell + umudugudu);
+	$j.getJSON(openmrsContextPath+"/module/rwandaprimarycare/ahValidateAddress.form", {
+		country:country, province:province, district:district, sector:sector, cell:cell, umudugudu:umudugudu
+		},  function (json){
+			$j.each(json.values, function(i, value) {
+				if(value.value == 1){
+					$j(someElement).empty();
+					$j(someElement).append($j(document.createElement("img")).attr("src",openmrsContextPath+"/images/checkmark.png"));
+				} else {
+					$j(someElement).empty();
+					$j(someElement).append($j(document.createElement("img")).attr("src",openmrsContextPath+"/images/error.gif"));
+				}
+			});
+		});
+	}
+
+function updateStructuredIcon(data){
+	alert(data);
+}
+
+
+function validateAddressesOnPage(){
+	
+	var structuredElements = $j(".isstructured");
+	var country, province, district, sector, cell, umudugudu;
+	
+	for(var i = 0; i < structuredElements.length; i++){
+		
+		country = getSiblingWithinValueFromClass(structuredElements[i],"countrySaveClass");
+		province = getSiblingWithinValueFromClass(structuredElements[i],"provinceSaveClass");
+		district = getSiblingWithinValueFromClass(structuredElements[i],"districtSaveClass");
+		sector = getSiblingWithinValueFromClass(structuredElements[i],"sectorSaveClass");
+		cell = getSiblingWithinValueFromClass(structuredElements[i],"cellSaveClass");
+		umudugudu = getSiblingWithinValueFromClass(structuredElements[i],"address1SaveClass");
+
+		if (country, province, district, sector, cell, umudugudu)
+			validateSingleAddress(structuredElements[i],country, province, district, sector, cell, umudugudu, null);
+
+	}
+}
+
+function getSiblingWithinValueFromClass(someElement,className){
+	
+	var td = $j(someElement).closest("table:visible")
+	.children("tbody")
+	.children("tr")
+	.children("td");
+	//alert("returning " + $j(td).children("."+className).val());
+	return $j(td).children("."+className).val().trim();
+}
+
+function getSiblingWithinTableFromClass(someElement,className){
+	
+	var td = $j(someElement).closest("table:visible")
+	.children("tbody:visible")
+	.children("tr:visible")
+	.children("td:visible");
+	return $j(td).children("."+className);
+}
+
+function validateAddressOnChange(targetElement){
+	
+	var structuredElement = getSiblingWithinTableFromClass(targetElement,"isstructured");
+	
+	var country = getSiblingWithinValueFromClass(structuredElement,"countrySaveClass");
+	var province = getSiblingWithinValueFromClass(structuredElement,"provinceSaveClass");
+	var district = getSiblingWithinValueFromClass(structuredElement,"districtSaveClass");
+	var sector = getSiblingWithinValueFromClass(structuredElement,"sectorSaveClass");
+	var cell = getSiblingWithinValueFromClass(structuredElement,"cellSaveClass");
+	var umudugudu = getSiblingWithinValueFromClass(structuredElement,"address1SaveClass");
+	
+	validateSingleAddress(structuredElement, country, province, district, sector, cell, umudugudu, targetElement);
+}
+
+
+$j(document).ready(
+
+		function() {
+			
+			$j(".countryClass").live(
+					"change",
+					function() {
+						if ($j(this).val() != "--") {
+							$j(".provinceClass:visible").children().remove();
+							$j(".districtClass:visible").children().remove();
+							$j(".sectorClass:visible").children().remove();
+							$j(".cellClass:visible").children().remove();
+							$j(".address1Class:visible").children().remove();
+							changeLocation($j(this).val(),
+									$j(".provinceClass:visible"));
+							$j(".countrySaveClass:visible").val(
+									$j(this).children(":selected").text());
+						}
+						validateAddressOnChange(this);
+					});
+
+			$j(".provinceClass").live(
+					"change",
+					function() {
+						if ($j(this).val() != "--") {
+							$j(".districtClass:visible ").children().remove();
+							$j(".sectorClass:visible ").children().remove();
+							$j(".cellClass:visible").children().remove();
+							$j(".address1Class:visible").children().remove();
+							changeLocation($j(this).val(),
+									$j(".districtClass:visible"));
+							$j(".provinceSaveClass:visible").val(
+									$j(this).children(":selected").text());
+						}
+						validateAddressOnChange(this);
+					});
+
+			$j(".districtClass").live(
+					"change",
+					function() {
+						if ($j(this).val() != "--") {
+							$j(".sectorClass:visible").children().remove();
+							$j(".cellClass:visible").children().remove();
+							$j(".address1Class:visible").children().remove();
+							changeLocation($j(this).val(),
+									$j(".sectorClass:visible"));
+							$j(".districtSaveClass:visible").val(
+									$j(this).children(":selected").text());
+						}
+						validateAddressOnChange(this)
+					});
+
+			$j(".sectorClass").live(
+					"change",
+					function() {
+						if ($j(this).val() != "--") {
+							$j(".cellClass:visible").children().remove();
+							$j(".address1Class:visible").children().remove();
+							changeLocation($j(this).val(),
+									$j(".cellClass:visible"));
+							$j(".sectorSaveClass:visible").val(
+									$j(this).children(":selected").text());
+						}
+						validateAddressOnChange(this)
+					});
+
+			$j(".cellClass").live(
+					"change",
+					function() {
+						if ($j(this).val() != "--") {
+							$j(".address1Class:visible").children().remove();
+							changeLocation($j(this).val(),
+									$j(".address1Class:visible"));
+							$j(".cellSaveClass:visible").val(
+									$j(this).children(":selected").text());
+						}
+						validateAddressOnChange(this)
+					});
+
+			$j(".address1Class").live(
+					"change",
+					function() {
+						
+						if ($j(this).val() != "--") {
+							$j(".address1SaveClass:visible").val(
+									$j(this).children(":selected").text());
+						}
+						validateAddressOnChange(this);
+					});
+			
+			
+			
+			
+			// ===================== handlers for changes in the text box ================== //
+			$j(".address1SaveClass").live(
+					"keyup",
+					function() {
+						validateAddressOnChange(this);
+					});
+			
+			$j(".cellSaveClass").live(
+					"keyup",
+					function() {
+						validateAddressOnChange(this);
+					});
+			
+			$j(".sectorSaveClass").live(
+					"keyup",
+					function() {
+						validateAddressOnChange(this);
+					});
+			$j(".districtSaveClass").live(
+					"keyup",
+					function() {
+						validateAddressOnChange(this);
+					});
+
+			$j(".provinceSaveClass").live(
+					"keyup",
+					function() {
+						validateAddressOnChange(this);
+					});
+			$j(".countrySaveClass").live(
+					"keyup",
+					function() {
+						validateAddressOnChange(this);
+					});
+			
+			
+			changeLocation(-1, $j(".countryClass"));
+			validateAddressesOnPage();		
+			
+			$j(".voided").live(
+					"change",
+					function() {
+						var voidedReasonRow = $j(this).closest("table")
+								.siblings("table").children("tbody").children(
+										".voidedReasonRowClass");
+						if (voidedReasonRow.css("display") == "none") {
+							voidedReasonRow.show("fast");
+						} else {
+							voidedReasonRow.hide("fast");
+						}
+					});
+
+			
+		});

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
 			<artifactId>htmlformentry-api</artifactId>
 			<version>${htmlformentryVersion}</version>
 			<type>jar</type>
-			<scope>test</scope>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.openmrs.module</groupId>


### PR DESCRIPTION
This PR moves the functionality out of the addresshierarchyrwanda module that was supporting the addressHierarchyRwanda tag in htmlformentry, and updates this functionality so that it continues to support it's functions while under the hood it now interacts with the addresshierarchy module.  This PR also introduces a bug fix where addresses were not being saved properly in cases where existing non-structured addresses were being edited.